### PR TITLE
PREMIUMAPP-3110 : Fix Cobalt state handling on focus change

### DIFF
--- a/plugin/CobaltImplementation.cpp
+++ b/plugin/CobaltImplementation.cpp
@@ -638,7 +638,8 @@ public:
   // IFocus
   uint32_t Focused(const bool focused) override {
     _adminLock.Lock();
-    if (_state == PluginHost::IStateControl::RESUMED || _statePending == PluginHost::IStateControl::RESUMED) {
+    if ((_state == PluginHost::IStateControl::RESUMED && _statePending != PluginHost::IStateControl::SUSPENDED) ||
+        _statePending == PluginHost::IStateControl::RESUMED) {
       if (focused)
         _sink.RequestForStateChange(StateChangeCommand::RESUME);
       else


### PR DESCRIPTION
Do not change Cobalt's state on focus change when Cobalt is about to go into suspended state.

Reason for change: Resolve problem encountered during YT25 certification
Test Procedure: See ticket
Risks: Low

Signed-off-by: Adam Stolcenburg <adam_stolcenburg@comcast.com>

Change-Id: Id71f15fa8dd79844e9ebb6d6e8f44ca519e89778