### PR TITLE
RDK-57592: avoid unintentional configuration of secondary pipeline

### DIFF
--- a/src/third_party/starboard/rdk/shared/player/player_internal.cc
+++ b/src/third_party/starboard/rdk/shared/player/player_internal.cc
@@ -42,6 +42,7 @@
 #include "starboard/common/once.h"
 #include "starboard/common/mutex.h"
 #include "starboard/common/condition_variable.h"
+#include "starboard/common/optional.h"
 #include "starboard/thread.h"
 #include "starboard/common/time.h"
 #include "starboard/memory.h"
@@ -428,6 +429,8 @@ void gst_cobalt_src_setup_and_add_app_src(SbMediaType media_type,
   src->priv->pad_number++;
   gst_bin_add(GST_BIN(element), appsrc);
 
+  GST_DEBUG_OBJECT(element, "added appsrc media_type=%u, %" GST_PTR_FORMAT, media_type, appsrc);
+
   GstElement* src_elem = appsrc;
   GstElement* decryptor = inject_decryptor ? CreateDecryptorElement(nullptr) : nullptr;
   GstElement* payloader = nullptr;
@@ -620,34 +623,49 @@ static void gst_cobalt_src_class_init(GstCobaltSrcClass* klass) {
   eklass->change_state = GST_DEBUG_FUNCPTR(gst_cobalt_src_change_state);
 }
 
-void ParseMaxVideoCapabilities(const char* caps_str, uint32_t *w, uint32_t *h, uint32_t *f) {
-  auto parse_entry = [&w, &h, &f](std::string& entry) {
-    auto end = std::remove_if(entry.begin(), entry.end(),
-      [](unsigned char c) { return std::isspace(c) || c == '"' || c == '\''; });
-    if (end != entry.end()) {
-      *end = '\0';
+struct MaxVideoCapabilities {
+  ::starboard::optional<uint32_t> width;
+  ::starboard::optional<uint32_t> height;
+  ::starboard::optional<uint32_t> framerate;
+  ::starboard::optional<uint32_t> streaming;
+
+  bool Parse(const char* caps_str) {
+    auto parse_entry = [this](std::string& entry) {
+      auto end = std::remove_if(entry.begin(), entry.end(),
+        [](unsigned char c) { return std::isspace(c) || c == '"' || c == '\''; });
+      if (end != entry.end()) {
+        *end = '\0';
+      }
+      auto mid = std::find(entry.begin(), end, '=');
+      if (mid == entry.begin() || (mid + 1) == end) {
+        return;
+      }
+      auto key_len = static_cast<size_t>(std::distance(entry.begin(), mid));
+      if ( ::strncasecmp("framerate", entry.c_str(), key_len) == 0 ) {
+        framerate = strtoul(&(*(mid + 1)), nullptr, 10);
+      }
+      else if ( ::strncasecmp("width", entry.c_str(), key_len) == 0 ) {
+        width = strtoul(&(*(mid + 1)), nullptr, 10);
+      }
+      else if ( ::strncasecmp("height", entry.c_str(), key_len) == 0 ) {
+        height = strtoul(&(*(mid + 1)), nullptr, 10);
+      }
+      else if ( ::strncasecmp("streaming", entry.c_str(), key_len) == 0 ) {
+        streaming = strtoul(&(*(mid + 1)), nullptr, 10);
+      }
+    };
+    std::istringstream ss(caps_str);
+    std::string txt;
+    while(std::getline(ss, txt, ';')) {
+      parse_entry(txt);
     }
-    auto mid = std::find(entry.begin(), end, '=');
-    if (mid == entry.begin() || (mid + 1) == end) {
-      return;
-    }
-    auto key_len = static_cast<size_t>(std::distance(entry.begin(), mid));
-    if ( f && ::strncasecmp("framerate", entry.c_str(), key_len) == 0 ) {
-      *f = strtoul(&(*(mid + 1)), nullptr, 10);
-    }
-    else if ( w && ::strncasecmp("width", entry.c_str(), key_len) == 0 ) {
-      *w = strtoul(&(*(mid + 1)), nullptr, 10);
-    }
-    else if ( h && ::strncasecmp("height", entry.c_str(), key_len) == 0 ) {
-      *h = strtoul(&(*(mid + 1)), nullptr, 10);
-    }
-  };
-  std::istringstream ss(caps_str);
-  std::string txt;
-  while(std::getline(ss, txt, ';')) {
-    parse_entry(txt);
+    return IsValid();
   }
-}
+
+  bool IsValid() const {
+    return width || height || framerate;
+  }
+};
 
 #if defined(GST_HAS_HDR_SUPPORT) && GST_HAS_HDR_SUPPORT
 static GstVideoColorRange RangeIdToGstVideoColorRange(SbMediaRangeId value) {
@@ -800,9 +818,9 @@ static void AddVideoInfoToGstCaps(const SbMediaVideoStreamInfo& info, GstCaps* c
     NULL);
 
   if (info.max_video_capabilities && *info.max_video_capabilities) {
-    uint32_t framerate = 0;
-    ParseMaxVideoCapabilities(info.max_video_capabilities, nullptr, nullptr, &framerate);
-    gst_caps_set_simple (caps, "framerate", GST_TYPE_FRACTION, framerate, 1, NULL);
+    MaxVideoCapabilities max_caps;
+    if (max_caps.Parse(info.max_video_capabilities) && max_caps.framerate)
+      gst_caps_set_simple (caps, "framerate", GST_TYPE_FRACTION, *max_caps.framerate, 1, NULL);
   }
 }
 
@@ -1486,7 +1504,9 @@ PlayerImpl::PlayerImpl(SbPlayer player,
 
   if (max_video_capabilities && *max_video_capabilities) {
     max_video_capabilities_ = max_video_capabilities;
-    ConfigureLimitedVideo();
+    MaxVideoCapabilities max_caps;
+    if (max_caps.Parse(max_video_capabilities) && max_caps.width && max_caps.height)
+      ConfigureLimitedVideo();
   }
 
   if (audio_codec_ == kSbMediaAudioCodecNone) {
@@ -2029,11 +2049,14 @@ void PlayerImpl::SetupElement(GstElement* pipeline,
 
     if (strstr(klass_str, "Video")) {
       if (!self->max_video_capabilities_.empty() &&
-          g_object_class_find_property(oclass, "maxVideoWidth") &&
-          g_object_class_find_property(oclass, "maxVideoHeight")) {
-            uint32_t width = 0, height = 0;
-            ParseMaxVideoCapabilities(self->max_video_capabilities_.c_str(), &width, &height, nullptr);
-            g_object_set(G_OBJECT(element), "maxVideoWidth", width, "maxVideoHeight", height, nullptr);
+          g_object_class_find_property(oclass, "max-video-width") &&
+          g_object_class_find_property(oclass, "max-video-height")) {
+            MaxVideoCapabilities max_caps;
+            if (max_caps.Parse(self->max_video_capabilities_.c_str()) && max_caps.width && max_caps.height)
+              g_object_set(G_OBJECT(element),
+                           "max-video-width",  *max_caps.width,
+                           "max-video-height", *max_caps.height,
+                           nullptr);
         }
     }
 
@@ -2139,10 +2162,16 @@ void PlayerImpl::WriteSample(SbMediaType sample_type,
   // in this case just drop the sample
   if (audio_codec_ == kSbMediaAudioCodecNone && sample_type == kSbMediaTypeAudio) {
     sample_deallocate_func_(player_, context_, sample_infos[0].buffer);
+    // keep demuxer going
+    ::starboard::ScopedLock lock(mutex_);
+    DecoderNeedsData(lock, MediaType::kAudio);
     return;
   }
   if (video_codec_ == kSbMediaVideoCodecNone && sample_type == kSbMediaTypeVideo) {
     sample_deallocate_func_(player_, context_, sample_infos[0].buffer);
+    // keep demuxer going
+    ::starboard::ScopedLock lock(mutex_);
+    DecoderNeedsData(lock, MediaType::kVideo);
     return;
   }
 


### PR DESCRIPTION
Cast mirror app signals a 'streaming' capability in max video caps which is incorrectly interpreted as secondary video pipeline