### PR TITLE
PREMIUMAPP-3381 Fix reading of keymap after evergreen update

### DIFF
--- a/src/third_party/starboard/rdk/shared/linux_key_mapping.cc
+++ b/src/third_party/starboard/rdk/shared/linux_key_mapping.cc
@@ -16,6 +16,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "third_party/starboard/rdk/shared/linux_key_mapping.h"
+#include "third_party/starboard/rdk/shared/system/system_get_path.h"
 
 #include <core/JSON.h>
 #include <core/Enumerate.h>
@@ -246,7 +247,14 @@ struct LinuxKeyMappingImpl {
   LinuxKeyMappingImpl() {
     const int kBufferSize = 256;
     char buffer[kBufferSize];
+
+    // kept for backward compatibility, however new keymaps should not be added
+    // in this location as it changes after evergeen update
     if (SbSystemGetPath(kSbSystemPathContentDirectory, buffer, kBufferSize)) {
+      ReadFromFile(std::string(buffer).append("/etc/keymapping.json"));
+    }
+
+    if (system::GetContentDirectory(buffer, kBufferSize)) {
       ReadFromFile(std::string(buffer).append("/etc/keymapping.json"));
     }
   }

--- a/src/third_party/starboard/rdk/shared/system/system_get_path.cc
+++ b/src/third_party/starboard/rdk/shared/system/system_get_path.cc
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include "system_get_path.h"
 #include "starboard/system.h"
 
 #include <linux/limits.h>
@@ -57,6 +58,13 @@ bool GetEvergreenContentPathOverride(char* out_path, int path_size) {
   return true;
 }
 #endif
+} // namespace
+
+namespace third_party {
+namespace starboard {
+namespace rdk {
+namespace shared {
+namespace system {
 
 bool GetContentDirectory(char* out_path, int path_size)
 {
@@ -71,7 +79,7 @@ bool GetContentDirectory(char* out_path, int path_size)
       std::string tmp = contentPath + testFilePath;
       struct stat info;
       if(stat(tmp.c_str(), &info) == 0){
-        return (starboard::strlcat<char>(out_path, contentPath.c_str(), path_size) < path_size);
+        return (::starboard::strlcpy<char>(out_path, contentPath.c_str(), path_size) < path_size);
       }
     }
 #if !SB_IS(EVERGREEN_COMPATIBLE)
@@ -81,8 +89,16 @@ bool GetContentDirectory(char* out_path, int path_size)
   }
 
   // Default to /usr/share/content/data if COBALT_CONTENT_PATH is not set
-  return (starboard::strlcat<char>(out_path, "/usr/share/content/data", path_size) < path_size);
+  return (::starboard::strlcpy<char>(out_path, "/usr/share/content/data", path_size) < path_size);
 }
+
+}  // namespace system
+}  // namespace shared
+}  // namespace rdk
+}  // namespace starboard
+}  // namespace third_party
+
+namespace {
 
 // Gets the path to the cache directory, using the home directory.
 bool GetCacheDirectory(char* out_path, int path_size) {
@@ -214,6 +230,8 @@ bool GetTemporaryDirectory(char* out_path, int path_size) {
 }  // namespace
 
 bool SbSystemGetPath(SbSystemPathId path_id, char* out_path, int path_size) {
+  using third_party::starboard::rdk::shared::system::GetContentDirectory;
+
   if (!out_path || !path_size) {
     return false;
   }

--- a/src/third_party/starboard/rdk/shared/system/system_get_path.h
+++ b/src/third_party/starboard/rdk/shared/system/system_get_path.h
@@ -32,10 +32,6 @@
 #ifndef THIRD_PARTY_STARBOARD_RDK_SHARED_SYSTEM_SYSTEM_GET_PATH_H_
 #define THIRD_PARTY_STARBOARD_RDK_SHARED_SYSTEM_SYSTEM_GET_PATH_H_
 
-#include "starboard/common/log.h"
-#include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
-#include "third_party/starboard/rdk/shared/log_override.h"
-
 namespace third_party {
 namespace starboard {
 namespace rdk {

--- a/src/third_party/starboard/rdk/shared/system/system_get_path.h
+++ b/src/third_party/starboard/rdk/shared/system/system_get_path.h
@@ -1,0 +1,53 @@
+//
+// Copyright 2020 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright 2016 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef THIRD_PARTY_STARBOARD_RDK_SHARED_SYSTEM_SYSTEM_GET_PATH_H_
+#define THIRD_PARTY_STARBOARD_RDK_SHARED_SYSTEM_SYSTEM_GET_PATH_H_
+
+#include "starboard/common/log.h"
+#include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
+#include "third_party/starboard/rdk/shared/log_override.h"
+
+namespace third_party {
+namespace starboard {
+namespace rdk {
+namespace shared {
+namespace system {
+
+bool GetContentDirectory(char* out_path, int path_size);
+
+}  // namespace system
+}  // namespace shared
+}  // namespace rdk
+}  // namespace starboard
+}  // namespace third_party
+
+#endif  // THIRD_PARTY_STARBOARD_RDK_SHARED_SYSTEM_SYSTEM_GET_PATH_H_


### PR DESCRIPTION
This change fixes reading of keymap after evergreen update, however for this to work the keymap location must be moved to one of the locations pointed by the COBALT_CONTENT_PATH environment variable (/usr/share/content/data by default) appended by the /etc/keymapping.json path. E.g.:
/usr/share/content/data/etc/keymapping.json