### PR TITLE
RDKEMW-11319 : Skip AddColorMetadataToGstCaps for low bit-depth

### DIFF
--- a/src/third_party/starboard/rdk/shared/player/player_internal.cc
+++ b/src/third_party/starboard/rdk/shared/player/player_internal.cc
@@ -772,6 +772,9 @@ static GstVideoColorPrimaries PrimaryIdToGstVideoColorPrimaries(SbMediaPrimaryId
 }
 
 static void AddColorMetadataToGstCaps(GstCaps* caps, const SbMediaColorMetadata& color_metadata) {
+  if (color_metadata.bits_per_channel < 8) {
+    return;
+  }
   if (IsSDRVideo(color_metadata.bits_per_channel,
                  color_metadata.primaries,
                  color_metadata.transfer,


### PR DESCRIPTION
RDKEMW-11319 : Skip AddColorMetadataToGstCaps when bits_per_channel < 8

Test Procedure: TBD
Risks: None
Signed-off-by: pravakar kumar patel <pravakarkumar_patel@comcast.com