### PR TITLE
RDK-58952: signal decrypt-to-host in gst caps

### DIFF
--- a/src/third_party/starboard/rdk/shared/player/player_internal.cc
+++ b/src/third_party/starboard/rdk/shared/player/player_internal.cc
@@ -67,6 +67,7 @@ static constexpr int kMaxNumberOfSamplesPerWrite = 1;
 static const char kCustomInstantRateChangeEventName[] = "custom-instant-rate-change";
 static const char kDidReceiveFirstSegmentMsgName[] = "did-receive-first-segment";
 static const char kDidReachBufferingTargetMsgName[] = "did-reach-buffering-target";
+static const char kDecryptToHostFieldName[] = "decrypt-to-host";
 
 // static
 int Player::MaxNumberOfSamplesPerWrite() {
@@ -1327,6 +1328,10 @@ class PlayerImpl : public Player {
   void HandleInititialSeek(::starboard::ScopedLock&);
   void DidEnd();
 
+  bool ShouldDecryptToHost() const {
+    return SbDrmSystemIsValid(drm_system_) && max_video_capabilities_.HasLowResolution();
+  }
+
   SbPlayer player_;
   SbWindow window_;
   SbMediaVideoCodec video_codec_;
@@ -2261,6 +2266,8 @@ void PlayerImpl::WriteSample(SbMediaType sample_type,
       GstCaps* gst_caps = CodecToGstCaps(video_codec_);
       if (gst_caps) {
         AddVideoInfoToGstCaps(info, gst_caps);
+        if (ShouldDecryptToHost())
+          gst_caps_set_simple (gst_caps, kDecryptToHostFieldName, G_TYPE_BOOLEAN, TRUE, nullptr);
         PrintGstCaps(gst_caps);
         gst_app_src_set_caps(GST_APP_SRC(video_appsrc_), gst_caps);
         gst_caps_replace(&video_caps_, gst_caps);
@@ -2279,6 +2286,8 @@ void PlayerImpl::WriteSample(SbMediaType sample_type,
       const auto& audio_info = sample_infos[0].audio_sample_info.stream_info;
       GstCaps* gst_caps = CodecToGstCaps(audio_codec_, &audio_info);
       if (gst_caps) {
+        if (ShouldDecryptToHost())
+          gst_caps_set_simple (gst_caps, kDecryptToHostFieldName, G_TYPE_BOOLEAN, TRUE, nullptr);
         PrintGstCaps(gst_caps);
         gst_app_src_set_caps(GST_APP_SRC(audio_appsrc_), gst_caps);
         if (audio_codec_ == kSbMediaAudioCodecVorbis || audio_codec_ == kSbMediaAudioCodecFlac)


### PR DESCRIPTION
Provide a hint to decryptor that it can decrypt to host memory for secondary video.