### PR TITLE
RDKEMW-20128: Set font package name overrides

### DIFF
--- a/src/third_party/starboard/rdk/shared/platform_configuration/configuration.gni
+++ b/src/third_party/starboard/rdk/shared/platform_configuration/configuration.gni
@@ -31,6 +31,8 @@
 import("//starboard/build/config/base_configuration.gni")
 
 cobalt_font_package = "limited"
+cobalt_font_package_override_named_fcc_fonts = 2
+cobalt_font_package_override_named_serif = 3
 final_executable_type = "shared_library"
 starboard_level_final_executable_type = "shared_library"
 


### PR DESCRIPTION
Reason for change: Fix for [RDKEMW][BCM][XFINITY]Unable to change font family from caption style in YouTube.
Test Procedure: Verify via test.
Risks: None identified.